### PR TITLE
Recolor archive button

### DIFF
--- a/src/courses_fix.js
+++ b/src/courses_fix.js
@@ -225,7 +225,7 @@ function addOrUpdateButton(li, courseId, isLocallyArchived, isDarkTheme) {
     const iconUrl = isLocallyArchived
         ? browser.runtime.getURL('icons/unarchive.svg')
         : browser.runtime.getURL('icons/archive.svg');
-    const iconColor = isDarkTheme ? '#FFFFFF' : '#4b5563';
+    const iconColor = isDarkTheme ? '#FFFFFF' : '#181a1c';
     iconSpan.style.cssText = `
         display: inline-block;
         width: 24px;


### PR DESCRIPTION
As you can see in the images above, the current version is less contrasting against the background cards. In my opinion, the archive button should be darker, and here is my version

---

<img width="546" height="357" alt="tg_image_3833515325" src="https://github.com/user-attachments/assets/6a5489ce-49da-409e-b3b7-7ee316defcf0" />
goes to
<img width="546" height="360" alt="tg_image_4122745303" src="https://github.com/user-attachments/assets/522101ef-e9c6-47ee-89e6-8f1eabce7586" />

---

<img width="546" height="358" alt="tg_image_3228817410" src="https://github.com/user-attachments/assets/ee9f8f8b-0860-48d4-bbfd-3592a349accd" />
goes to
<img width="546" height="360" alt="tg_image_2698805377" src="https://github.com/user-attachments/assets/3e64c785-362e-4a2f-a6b6-57c7ee4b617d" />
