### PR TITLE
Возможность изменить формат отображения предстоящих КР + автоскролл до последней недели в странице курса (#66, #102)

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -47,7 +47,8 @@ function handleNavigation(tabId, url) {
         browser.scripting.executeScript({
             target: { tabId: tabId },
             files: ["browser-polyfill.js", "course_card_simplifier.js",
-                    "future_exams_view.js", "courses_fix.js", "course_overview_task_status.js"]
+                    "future_exams_view.js", "courses_fix.js", "course_overview_task_status.js",
+                    "course_overview_autoscroll.js"]
         }).catch(err => console.error(`[BG_LOG] Error injecting courses_fix.js:`, err));
     }
     if (url.includes("/longreads/")) {

--- a/src/course_overview_autoscroll.js
+++ b/src/course_overview_autoscroll.js
@@ -1,0 +1,35 @@
+async function activateCourseOverviewAutoscroll() {
+    try {
+        const courseOverview = await waitForElement('cu-course-overview', 10000);
+        const existingAccordion = courseOverview.querySelector('tui-accordion.cu-accordion.themes-accordion');
+        
+        if (!existingAccordion) {
+            console.log('Accordion not found in cu-course-overview');
+            return;
+        }
+
+        const accordionItems = Array.from(existingAccordion.querySelectorAll('tui-accordion-item'))
+            .filter(item => item.getAttribute('data-item-type') !== 'future-exam');
+
+        if (accordionItems.length === 0) {
+            console.log('No non-future-exam accordion items found');
+            return;
+        }
+
+        const lastItem = accordionItems[accordionItems.length - 1];
+        console.log('Scrolling to last accordion item:', lastItem);
+        lastItem.scrollIntoView({ 
+            behavior: 'smooth', 
+            block: 'center' 
+        });
+
+        
+        const button = lastItem.querySelector('button');
+        if (button) {
+            button.click();
+        }
+
+    } catch (e) {
+        console.log('cu-course-overview not found within timeout:', e);
+    }
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -103,6 +103,29 @@
         .disabled {
             opacity: 0.6;
         }
+
+        .dropdown-container {
+            position: relative;
+            width: 100%;
+        }
+
+        .dropdown-select {
+            width: 100%;
+            padding: 8px 12px;
+            font-family: 'Inter', sans-serif;
+            font-size: 15px;
+            color: #333;
+            background-color: #f8f8f8;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            appearance: none;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 9L1 4h10z'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 12px center;
+            padding-right: 32px;
+        }
     </style>
 </head>
 
@@ -166,6 +189,26 @@
                 <span class="slider"></span>
             </label>
         </div>
+        <div class="toggle-container" id="future-exams-display-container" style="display: none;">
+            <span class="toggle-label">Формат отображения:</span>
+            <div class="dropdown-container">
+              <select class="dropdown-select" id="future-exams-display-format">
+                  <option value="date">Разброс дат</option>
+                  <option value="week">Неделя</option>
+              </select>
+            </div>
+        </div>
+    </div>
+
+    <div class="section">
+      <h3>Разные мелочи</h3>
+      <div class="toggle-container">
+          <span class="toggle-label">Автоскролл до последней недели в обзоре курса:</span>
+          <label class="switch">
+              <input type="checkbox" id="course-overview-autoscroll-toggle">
+              <span class="slider"></span>
+          </label>
+      </div>
     </div>
 
     <!-- === ЭЛЕМЕНТ УВЕДОМЛЕНИЯ === -->

--- a/src/popup.js
+++ b/src/popup.js
@@ -36,11 +36,15 @@ const toggles = {
     courseOverviewTaskStatusToggle: document.getElementById('course-overview-task-status-toggle'),
     emojiHeartsEnabled: document.getElementById('emoji-hearts-toggle'),
     oldCoursesDesignToggle: document.getElementById('old-courses-design-toggle'),
-    futureExamsViewToggle: document.getElementById('future-exams-view-toggle')
+    futureExamsViewToggle: document.getElementById('future-exams-view-toggle'),
+    courseOverviewAutoscrollToggle: document.getElementById('course-overview-autoscroll-toggle'),
 };
 
+const futureExamsDisplayContainer = document.getElementById('future-exams-display-container');
+const futureExamsDisplayFormat = document.getElementById('future-exams-display-format');
+
 const reloadNotice = document.getElementById('reload-notice');
-const allKeys = Object.keys(toggles);
+const allKeys = [...Object.keys(toggles), 'futureExamsDisplayFormat'];
 let pendingChanges = {};
 
 /**
@@ -59,7 +63,23 @@ function refreshToggleStates() {
         }
         // Применяем тему к самому popup
         applyPopupTheme(!!data.themeEnabled);
+
+        // Апдейты отображения полей, зависящих от состояний переключателей
+        updateFormatDisplayVisibility(data.futureExamsDisplayFormat);
     });
+}
+
+function updateFormatDisplayVisibility(displayFormat) {
+  if (toggles['futureExamsViewToggle'].checked) {
+    futureExamsDisplayContainer.style.display = 'block';
+  }
+  else {
+    futureExamsDisplayContainer.style.display = 'none';
+  }
+
+  if (futureExamsDisplayFormat && displayFormat) {
+    futureExamsDisplayFormat.value = displayFormat;
+  }
 }
 
 // 1. Добавляем обработчики, которые работают по-разному в зависимости от контекста
@@ -94,6 +114,10 @@ allKeys.forEach(key => {
                     }
                 }
             }
+
+            if (key === 'futureExamsViewToggle') {
+                updateFormatDisplayVisibility();
+            }
         });
     }
 });
@@ -116,6 +140,21 @@ if (isInsideIframe) {
             // Сбрасываем изменения и скрываем плашку
             pendingChanges = {}; 
             if (reloadNotice) reloadNotice.style.display = 'none';
+        }
+    });
+}
+
+if (futureExamsDisplayFormat) {
+    futureExamsDisplayFormat.addEventListener('change', () => {
+        const selectedFormat = futureExamsDisplayFormat.value;
+        
+        if (isInsideIframe) {
+            // В iframe накапливаем изменения
+            if (reloadNotice) reloadNotice.style.display = 'block';
+            pendingChanges['futureExamsDisplayFormat'] = selectedFormat;
+        } else {
+            // В popup браузера сохраняем сразу
+            browser.storage.sync.set({ futureExamsDisplayFormat: selectedFormat });
         }
     });
 }


### PR DESCRIPTION
Добавлена возможность изменить формат отображения даты (неделя/разброс дат) + автоскролл до последней недели курса с ее открытием

<img width="258" height="290" alt="image" src="https://github.com/user-attachments/assets/8ea2b121-d893-4691-b941-fb19d198afd5" />
<img width="632" height="240" alt="image" src="https://github.com/user-attachments/assets/21741c7d-0e5d-4cd5-a165-7ae70907aac5" />

closes https://github.com/cu-3rd-party/lms-extension/issues/66
closes https://github.com/cu-3rd-party/lms-extension/issues/102