### PR TITLE
fix: пересинхронизировать фильтр курсов при смене семестра

### DIFF
--- a/src/plugins/courses/tasks_fix.js
+++ b/src/plugins/courses/tasks_fix.js
@@ -573,14 +573,16 @@ if (typeof window.__culmsTasksFixInitialized === 'undefined') {
   const masterCourseList = new Set();
   let selectedStatuses = new Set(HARDCODED_STATUSES);
   let selectedCourses = new Set();
+  let knownCourses = new Set();
 
   function loadFilterSettings() {
     try {
       const savedFilters = localStorage.getItem(FILTER_STORAGE_KEY);
       if (savedFilters) {
-        const { statuses, courses } = JSON.parse(savedFilters);
+        const { statuses, courses, knownCourses: savedKnown } = JSON.parse(savedFilters);
         if (statuses && Array.isArray(statuses)) selectedStatuses = new Set(statuses);
         if (courses && Array.isArray(courses)) selectedCourses = new Set(courses);
+        if (savedKnown && Array.isArray(savedKnown)) knownCourses = new Set(savedKnown);
         window.cuLmsLog('Task Status Updater: Filter settings loaded from storage');
       }
     } catch (error) {
@@ -594,6 +596,7 @@ if (typeof window.__culmsTasksFixInitialized === 'undefined') {
       const filterData = {
         statuses: Array.from(selectedStatuses),
         courses: Array.from(selectedCourses),
+        knownCourses: Array.from(masterCourseList),
         timestamp: new Date().toISOString(),
       };
       localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(filterData));
@@ -611,10 +614,23 @@ if (typeof window.__culmsTasksFixInitialized === 'undefined') {
           const courseName = el.textContent.trim();
           if (courseName) masterCourseList.add(courseName);
         });
-      if (selectedCourses.size === 0) {
+
+      if (knownCourses.size === 0) {
+        // Нет сохранённых данных — выбираем все курсы
         masterCourseList.forEach((course) => selectedCourses.add(course));
+      } else {
+        // Убираем устаревшие курсы (которых нет в DOM)
+        selectedCourses.forEach((course) => {
+          if (!masterCourseList.has(course)) selectedCourses.delete(course);
+        });
+        // Добавляем новые курсы (которых не было раньше) как выбранные
+        masterCourseList.forEach((course) => {
+          if (!knownCourses.has(course)) selectedCourses.add(course);
+        });
       }
+
       window.cuLmsLog('Task Status Updater: Master course list created with saved selections.');
+      saveFilterSettings();
     }
     applyCombinedFilter();
   }

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,11 +1,15 @@
 import { test as base, type BrowserContext } from '@playwright/test';
 import {
-  LMS_URL,
   clearAllExtensionStorage,
-  clearExtensionStorage,
   launchAuthenticatedExtensionContext,
   resolveExtensionId,
+} from './extension.js';
+
+export { expect } from '@playwright/test';
+export {
+  LMS_URL,
   setExtensionStorage,
+  clearExtensionStorage,
 } from './extension.js';
 
 type WorkerFixtures = { workerContext: BrowserContext; extensionId: string };
@@ -44,77 +48,3 @@ export const test = base.extend<{ context: BrowserContext }, WorkerFixtures>({
 });
 
 
-async function openExtensionPage(context: BrowserContext, extensionId: string) {
-  const extensionUrl = `chrome-extension://${extensionId}/popup/popup.html`;
-  let lastError: unknown;
-
-  for (let attempt = 0; attempt < 3; attempt++) {
-    const page = await context.newPage();
-
-    try {
-      await page.goto(extensionUrl, { waitUntil: 'domcontentloaded' });
-      return page;
-    } catch (error) {
-      lastError = error;
-      await page.close();
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
-  }
-
-  throw lastError;
-}
-
-/**
- * Записывает значение в chrome.storage через popup-страницу расширения.
- */
-export async function setExtensionStorage(
-  context: BrowserContext,
-  extensionId: string,
-  area: 'local' | 'sync',
-  key: string,
-  value: unknown
-): Promise<void> {
-  if (!extensionId) return;
-  const page = await openExtensionPage(context, extensionId);
-  await page.evaluate(
-    ({ area, key, value }) =>
-      area === 'local'
-        ? chrome.storage.local.set({ [key]: value })
-        : chrome.storage.sync.set({ [key]: value }),
-    { area, key, value }
-  );
-  await page.close();
-}
-
-/**
- * Очищает chrome.storage через popup-страницу расширения.
- * Надёжнее чем service worker — SW MV3 завершается Chrome в любой момент.
- */
-export async function clearExtensionStorage(
-  context: BrowserContext,
-  extensionId: string,
-  area: 'local' | 'sync',
-  key: string
-): Promise<void> {
-  if (!extensionId) return;
-  const page = await openExtensionPage(context, extensionId);
-  await page.evaluate(
-    ({ area, key }) =>
-      area === 'local' ? chrome.storage.local.remove(key) : chrome.storage.sync.remove(key),
-    { area, key }
-  );
-  await page.close();
-}
-
-async function clearAllExtensionStorage(
-  context: BrowserContext,
-  extensionId: string
-): Promise<void> {
-  if (!extensionId) return;
-  const page = await openExtensionPage(context, extensionId);
-  await page.evaluate(async () => {
-    await chrome.storage.local.clear();
-    await chrome.storage.sync.clear();
-  });
-  await page.close();
-}

--- a/tests/issues/issue-216.test.ts
+++ b/tests/issues/issue-216.test.ts
@@ -1,0 +1,126 @@
+import { test, expect, LMS_URL } from '../helpers/fixtures.js';
+
+const TASKS_PAGE = `${LMS_URL}/learn/tasks/actual-student-tasks`;
+const FILTER_KEY = 'cu.lms.actual-student-tasks-custom-filter';
+
+async function waitForTasksLoaded(page) {
+  // state: 'attached' — достаточно, чтобы строки появились в DOM (некоторые могут быть скрыты фильтром)
+  await page.waitForSelector('tr[class*="task-table__task"]', { state: 'attached', timeout: 15_000 });
+  await page.waitForSelector('[data-culms-weight-cell]', { state: 'attached', timeout: 10_000 });
+}
+
+async function getVisibleTaskRows(page) {
+  return page.locator('tr[class*="task-table__task"]').filter({ has: page.locator(':not([style*="display: none"])') }).evaluateAll((rows) =>
+    rows.filter((r) => r.style.display !== 'none').length
+  );
+}
+
+async function getTotalTaskRows(page) {
+  return page.locator('tr[class*="task-table__task"]').count();
+}
+
+async function getCurrentCourseNames(page): Promise<string[]> {
+  return page.locator('tr[class*="task-table__task"] .task-table__course-name').evaluateAll(
+    (els) => [...new Set(els.map((el) => el.textContent.trim()).filter(Boolean))]
+  );
+}
+
+test.describe('Issue #216: фильтр курсов при смене семестра', () => {
+  test.setTimeout(60_000);
+
+  test('старый формат без knownCourses: все задачи видны после перезагрузки', async ({ page }) => {
+    await page.goto(TASKS_PAGE);
+    await waitForTasksLoaded(page);
+
+    const total = await getTotalTaskRows(page);
+    expect(total).toBeGreaterThan(0);
+
+    // Имитируем старый формат localStorage — без knownCourses, с несуществующими курсами
+    await page.evaluate((key) => {
+      const stale = {
+        statuses: ['В работе', 'Есть решение', 'На проверке', 'Не начато', 'Аудиторная', 'Метод скипа', 'Доработка'],
+        courses: ['Математический анализ. 1 семестр', 'Линейная алгебра. 1 семестр'],
+        // knownCourses отсутствует — старый формат
+        timestamp: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      localStorage.setItem(key, JSON.stringify(stale));
+    }, FILTER_KEY);
+
+    await page.reload();
+    await waitForTasksLoaded(page);
+
+    const visible = await getVisibleTaskRows(page);
+    expect(visible).toBe(total);
+  });
+
+  test('курсы нового семестра автоматически выбираются', async ({ page }) => {
+    await page.goto(TASKS_PAGE);
+    await waitForTasksLoaded(page);
+
+    const currentCourses = await getCurrentCourseNames(page);
+    expect(currentCourses.length).toBeGreaterThan(0);
+
+    // Имитируем состояние после смены семестра:
+    // knownCourses содержит только старые курсы, которых нет в DOM
+    await page.evaluate(({ key, courses }) => {
+      const stale = {
+        statuses: ['В работе', 'Есть решение', 'На проверке', 'Не начато', 'Аудиторная', 'Метод скипа', 'Доработка'],
+        courses: ['Старый курс 1 семестра', 'Ещё один старый курс'],
+        knownCourses: ['Старый курс 1 семестра', 'Ещё один старый курс'],
+        timestamp: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      localStorage.setItem(key, JSON.stringify(stale));
+    }, { key: FILTER_KEY, courses: currentCourses });
+
+    await page.reload();
+    await waitForTasksLoaded(page);
+
+    const total = await getTotalTaskRows(page);
+    const visible = await getVisibleTaskRows(page);
+    expect(visible).toBe(total);
+  });
+
+  test('явно снятый пользователем курс остаётся снятым после перезагрузки', async ({ page }) => {
+    await page.goto(TASKS_PAGE);
+    await waitForTasksLoaded(page);
+
+    const currentCourses = await getCurrentCourseNames(page);
+    expect(currentCourses.length).toBeGreaterThan(1);
+
+    const deselectedCourse = currentCourses[0];
+    const selectedCourses = currentCourses.slice(1);
+
+    // Имитируем ситуацию: пользователь снял один курс
+    // knownCourses содержит ВСЕ текущие курсы — значит курс известен, но снят намеренно
+    await page.evaluate(({ key, selected, known }) => {
+      localStorage.setItem(key, JSON.stringify({
+        statuses: ['В работе', 'Есть решение', 'На проверке', 'Не начато', 'Аудиторная', 'Метод скипа', 'Доработка'],
+        courses: selected,
+        knownCourses: known,
+        timestamp: new Date().toISOString(),
+      }));
+    }, { key: FILTER_KEY, selected: selectedCourses, known: currentCourses });
+
+    await page.reload();
+    await waitForTasksLoaded(page);
+
+    // Задачи снятого курса должны быть скрыты
+    const hiddenRows = await page.locator('tr[class*="task-table__task"]').evaluateAll(
+      (rows, course) => rows.filter(
+        (r) => r.style.display === 'none' &&
+               r.querySelector('.task-table__course-name')?.textContent.trim() === course
+      ).length,
+      deselectedCourse
+    );
+
+    const totalForCourse = await page.locator('tr[class*="task-table__task"]').evaluateAll(
+      (rows, course) => rows.filter(
+        (r) => r.querySelector('.task-table__course-name')?.textContent.trim() === course
+      ).length,
+      deselectedCourse
+    );
+
+    expect(totalForCourse).toBeGreaterThan(0);
+    expect(hiddenRows).toBe(totalForCourse);
+  });
+});


### PR DESCRIPTION
При смене семестра курсы из старого семестра оставались в selectedCourses, а новые не добавлялись — задачи нового семестра скрывались фильтром.

Добавлено поле knownCourses в сохранённые настройки фильтра. При инициализации новые курсы (не в knownCourses) автоматически выбираются, устаревшие (не в DOM) — убираются из выбранных. Явный выбор пользователя сохраняется.

Также исправлен дублирующийся экспорт в tests/helpers/fixtures.ts.

Closes #216